### PR TITLE
Migrate file title generation on upload to a CSP compliant approach using Stimulus & TypeScript

### DIFF
--- a/client/src/controllers/SyncController.ts
+++ b/client/src/controllers/SyncController.ts
@@ -25,14 +25,41 @@ export class SyncController extends Controller<HTMLInputElement> {
     debounce: { default: 100, type: Number },
     delay: { default: 0, type: Number },
     disabled: { default: false, type: Boolean },
+    name: { default: '', type: String },
+    normalize: { default: false, type: Boolean },
     quiet: { default: false, type: Boolean },
-    target: String,
+    target: { default: '', type: String },
   };
 
+  /**
+   * The delay, in milliseconds, to wait before running apply if called multiple
+   * times consecutively.
+   */
   declare debounceValue: number;
+  /**
+   * The delay, in milliseconds, to wait before applying the value to the target elements.
+   */
   declare delayValue: number;
+  /**
+   * If true, the sync controller will not apply the value to the target elements.
+   * Dynamically set when there are no valid target elements to sync with or when all
+   * target elements have the apply event prevented on either the `start` or `check` methods.
+   */
   declare disabledValue: boolean;
+  /**
+   * A name value to support differentiation between events.
+   */
+  declare nameValue: string;
+  /**
+   * If true, the value to sync will be normalized.
+   * @example If the value is a file path, the normalized value will be the file name.
+   */
+  declare normalizeValue: boolean;
+  /**
+   * If true, the value will be set on the target elements without dispatching a change event.
+   */
   declare quietValue: boolean;
+
   declare readonly targetValue: string;
 
   /**
@@ -41,8 +68,9 @@ export class SyncController extends Controller<HTMLInputElement> {
    * default.
    */
   connect() {
-    this.processTargetElements('start', true);
+    this.processTargetElements('start', { resetDisabledValue: true });
     this.apply = debounce(this.apply.bind(this), this.debounceValue);
+    console.log('SyncController connected to:', this.element);
   }
 
   /**
@@ -50,7 +78,7 @@ export class SyncController extends Controller<HTMLInputElement> {
    * whether this sync controller should be disabled.
    */
   check() {
-    this.processTargetElements('check', true);
+    this.processTargetElements('check', { resetDisabledValue: true });
   }
 
   /**
@@ -62,11 +90,11 @@ export class SyncController extends Controller<HTMLInputElement> {
    * based on the controller's `delayValue`.
    */
   apply(event?: Event & { params?: { apply?: string } }) {
-    const valueToApply = event?.params?.apply || this.element.value;
-
+    const value = this.prepareValue(event?.params?.apply || this.element.value);
+    console.log('apply method called');
     const applyValue = (target) => {
       /* use setter to correctly update value in non-inputs (e.g. select) */ // eslint-disable-next-line no-param-reassign
-      target.value = valueToApply;
+      target.value = value;
 
       if (this.quietValue) return;
 
@@ -77,7 +105,7 @@ export class SyncController extends Controller<HTMLInputElement> {
       });
     };
 
-    this.processTargetElements('apply').forEach((target) => {
+    this.processTargetElements('apply', { value }).forEach((target) => {
       if (this.delayValue) {
         setTimeout(() => {
           applyValue(target);
@@ -109,35 +137,57 @@ export class SyncController extends Controller<HTMLInputElement> {
    * Simple method to dispatch a ping event to the targeted elements.
    */
   ping() {
-    this.processTargetElements('ping', false, { bubbles: true });
+    this.processTargetElements('ping');
+  }
+
+  prepareValue(value: string) {
+    if (!this.normalizeValue) return value;
+
+    if (this.element.type === 'file') {
+      return value
+        .split('\\')
+        .slice(-1)[0]
+        .replace(/\.[^.]+$/, '');
+    }
+
+    return value;
   }
 
   /**
    * Returns the non-default prevented elements that are targets of this sync
    * controller. Additionally allows this processing to enable or disable
-   * this controller instance's sync behavior.
+   * this controller instance's sync behaviour.
    */
   processTargetElements(
     eventName: string,
-    resetDisabledValue = false,
-    options = {},
+    { resetDisabledValue = false, value = this.element.value } = {},
   ) {
+    console.log('Processing target elements for event:', eventName);
     if (!resetDisabledValue && this.disabledValue) {
+      // console.log('Sync is disabled, skipping.');
       return [];
     }
 
     const targetElements = [
       ...document.querySelectorAll<HTMLElement>(this.targetValue),
     ];
+    // console.log('Target elements found:', targetElements);
+
+    const element = this.element;
+    const name = this.nameValue;
 
     const elements = targetElements.filter((target) => {
+      const maxLength = Number(target.getAttribute('maxlength')) || null;
+      const required = !!target.hasAttribute('required');
+
       const event = this.dispatch(eventName, {
-        bubbles: false,
+        bubbles: true, // Ensure this is true
         cancelable: true,
-        ...options, // allow overriding some options but not detail & target
-        detail: { element: this.element, value: this.element.value },
-        target: target as HTMLInputElement,
+        detail: { element, maxLength, name, required, value },
+        target,
       });
+      // console.log('Event dispatched:', event);
+      // console.log('Event target:', target);
 
       return !event.defaultPrevented;
     });
@@ -147,5 +197,84 @@ export class SyncController extends Controller<HTMLInputElement> {
     }
 
     return elements;
+  }
+
+  /**
+   * Could use afterload or something to add backwards compatibility with documented
+   * 'wagtail:images|documents-upload' approach.
+   */
+  static afterLoad(identifier: string) {
+    // console.log('is this working?', { identifier });
+    if (identifier !== 'w-sync') return;
+
+    // domReady().then(() => {
+    // Why does domReady not work???
+
+    // console.log('is this working?');
+
+    /**
+     * Need to think this through.
+     * I only really want this on specific fields
+     * We could normalize all values but is that bad?
+     * Need to consider issues with bubbling actions
+     * Maybe... using Ping instead for now?
+     */
+
+    const handleEvent = (
+      event: CustomEvent<{
+        maxLength: number | null;
+        name: string;
+        value: string;
+      }>,
+    ) => {
+      // console.log('sync apply! before', event);
+      const {
+        /** Will be the target title field */
+        target,
+      } = event;
+      if (!target || !(target instanceof HTMLInputElement)) return;
+      const form = target.closest('form');
+      if (!form) return;
+
+      // console.log('sync apply!', event);
+
+      const { maxLength: maxTitleLength, name, value: title } = event.detail;
+
+      if (!name || !title) return;
+
+      const data = { title };
+
+      const filename = target.value;
+
+      const wrapperEvent = form.dispatchEvent(
+        new CustomEvent(name, {
+          bubbles: true,
+          cancelable: true,
+          detail: {
+            ...event.detail,
+            data,
+            filename,
+            maxTitleLength,
+          },
+        }),
+      );
+
+      if (!wrapperEvent) {
+        // Do not set a title if event.preventDefault(); is called by handler
+
+        event.preventDefault();
+      }
+
+      if (data.title !== title) {
+        // If the title has been modified through another listener, update the title field manually, ignoring the default behaviour
+        //  or we just always do this???
+        event.preventDefault();
+        target.value = data.title;
+        // maybe dispatch change event - check what jQuery .val does out of the box & check docs!!
+      }
+    };
+
+    document.addEventListener('w-sync:apply', handleEvent as EventListener);
+    // });
   }
 }


### PR DESCRIPTION
**Solves issue #12994**  

This PR begins refactoring document and image title generation on upload by introducing the `SyncController`, with future enhancements planned for `CleanController`.  

### Changes in this PR:
- Implemented a proof-of-concept for migrating title synchronization logic from jQuery inline scripts to Stimulus controllers.
- Updated the SyncController to handle title synchronization based on LB's prior attempt ([[link](https://github.com/lb-/wagtail/commits/wip/move-upload-title-to-sync-controller/)](https://github.com/lb-/wagtail/commits/wip/move-upload-title-to-sync-controller/)).
- Added a test for backwards compatibility (**commented out for now** until its necessity is confirmed).
- Updated existing tests for SyncController.

### Next Steps & Considerations:
- Enhancing `CleanController` (formerly `SlugController`) to clean filenames into user-friendly titles using regex.
- Addressing bulk upload behavior, which currently relies on jQuery (`formData` usage in `add-multiple.js`).
- Defining a naming convention and a deprecation path for older event-based approaches.
- Ensuring compatibility with CSP refactor work (#12940, #1288).

This PR is a **starting point**, and additional work is needed before full migration from jQuery.
